### PR TITLE
Fix mouse not working on Firefox

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -77,6 +77,8 @@ var selectedMaterial = "dirt";
 var selectedViewMode = "normal";
 const BASE_SIZE = 4;
 
+// browser detection
+var browserIsFirefox = (typeof InstallTrigger !== 'undefined');
 
 function styleHeader() {
     var nonbold_headers = [
@@ -387,8 +389,8 @@ function doMouseHover() {
     if (lastMoveEvent == null) {
         return;
     }
-    var px = lastMoveEvent.offsetX / BASE_SIZE;
-    var py = lastMoveEvent.offsetY / BASE_SIZE;
+    var px = getMouseEventX(lastMoveEvent) / BASE_SIZE;
+    var py = getMouseEventY(lastMoveEvent) / BASE_SIZE;
     iterateOnOrganisms((org) => org.hovered = false);
     getOrganismSquaresAtSquare(Math.floor(px), Math.floor(py)).forEach((orgSq) => orgSq.linkedOrganism.hovered = true);
 }
@@ -432,15 +434,31 @@ function addSquareByName(posX, posY, name) {
     };
 }
 
+function getMouseEventX(evt) {
+    // Firefox does not support offsetX
+    if(browserIsFirefox)
+        return evt.layerX;
+
+    return evt.offsetX;
+}
+
+function getMouseEventY(evt) {
+    // Firefox does not support offsetY
+    if(browserIsFirefox)
+        return evt.layerY;
+
+    return evt.offsetY;
+}
+
 function doClickAdd() {
     if (lastMoveEvent == null) {
         return;
     }
     if (mouseDown > 0) {
-        var offsetX = lastMoveEvent.offsetX / BASE_SIZE;
-        var offsetY = lastMoveEvent.offsetY / BASE_SIZE;
-        var prevOffsetX = (lastLastClickEvent == null ? lastMoveEvent : lastLastClickEvent).offsetX / BASE_SIZE;
-        var prevOffsetY = (lastLastClickEvent == null ? lastMoveEvent : lastLastClickEvent).offsetY / BASE_SIZE;
+        var offsetX = getMouseEventX(lastMoveEvent) / BASE_SIZE;
+        var offsetY = getMouseEventY(lastMoveEvent)  / BASE_SIZE;
+        var prevOffsetX = getMouseEventX((lastLastClickEvent == null ? lastMoveEvent : lastLastClickEvent)) / BASE_SIZE;
+        var prevOffsetY = getMouseEventY((lastLastClickEvent == null ? lastMoveEvent : lastLastClickEvent)) / BASE_SIZE;
 
         // point slope motherfuckers 
 


### PR DESCRIPTION
Firefox does not support the offsetX and offsetY properties of mouse events. Therefore the demo did not work properly and behaved as if the user was always clicking at location (0,0).

This fix checks whether the browser is Firefox (according to 
[[1]](https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browsers)). If this is the case, it uses a different property instead of offsetX/offsetY. Tested locally on Firefox 133.0.3.

I am new to JavaScript, so I hope the commit is acceptable.



Screenshot below of it now working in Firefox. The material is added at the mouse pointer's location, as expected (unfortunately the mouse pointer is not shown in the screenshot).

Before:
![image](https://github.com/user-attachments/assets/4833bfa9-3a55-4a0c-9916-dd436b7bbc4d)

After:
![image](https://github.com/user-attachments/assets/66c4b0a0-78b8-4885-b361-f6be019034e2)


